### PR TITLE
Fixed a few broken links and a typo.

### DIFF
--- a/1-source-code/3-reading/1-godoc.md
+++ b/1-source-code/3-reading/1-godoc.md
@@ -114,7 +114,7 @@ many packages import every repository.
 
 Go check it out and try to find some useful packages to your work!
 
-## Congraulations
+## Congratulations
 
 You now know not only how to use `godoc` and `go doc` but also the
 differences between those two. You can go around and ask other gophers

--- a/1-source-code/README.md
+++ b/1-source-code/README.md
@@ -4,8 +4,8 @@ In this section we will cover all the different tools that gophers use to manage
 code bases. This includes:
 
 - [1: Worskpace management](1-workspace/1-intro.md) - how to organize a workspace according to Go best practices.
-- [2: Edition tools](2-writing/README.md) - tools to help writing code, such as editors, plugins, and pretty printers.
-- [3: Navigation tools](3-reading/README.md) - tools to understand and navigate existing code bases.
+- [2: Edition tools](2-writing/1-editors-and-plugins.md) - tools to help writing code, such as editors, plugins, and pretty printers.
+- [3: Navigation tools](3-reading/1-godoc.md) - tools to understand and navigate existing code bases.
 
 Everything here is related to source code, in the next section we cover how from that code
 you can build artifacts such as binaries and container images.


### PR DESCRIPTION
On https://github.com/campoy/go-tooling-workshop/blob/master/1-source-code/README.md

The links for `2: Edition tools` and `3: Navigation tools` both go to README.md files that don't exist. 

There is also a typo in https://github.com/joncalhoun/go-tooling-workshop/blob/master/1-source-code/3-reading/1-godoc.md (The word Congratulations is missing the first `t`).

This fixes all of those (I believe).