### PR TITLE
Move MustCompile to a global var

### DIFF
--- a/3-dynamic-analysis/webserver/main.go
+++ b/3-dynamic-analysis/webserver/main.go
@@ -21,13 +21,16 @@ import (
 	"regexp"
 )
 
+var(
+	re = regexp.MustCompile("^([[:alpha:]]+)@golang.org$")
+)
+
 func main() {
 	http.HandleFunc("/", handler)
 	log.Fatal(http.ListenAndServe("localhost:8080", nil))
 }
 
 func handler(w http.ResponseWriter, r *http.Request) {
-	re := regexp.MustCompile("^([[:alpha:]]+)@golang.org$")
 	match := re.FindStringSubmatch(r.URL.Path)
 	if len(match) == 1 {
 		fmt.Fprintf(w, "hello, %s", match[1])


### PR DESCRIPTION
If `regexp.MustCompile()` is inside a handler, it will run every single time that the handler is executed. `regexp.MustCompile()` functions should only run once when the code compiles and the server starts up for performance reasons. Coworker learned this the hard way when I was helping him figure out why his loop was so slow.

I do have a signature with Google Individual Contributor License Agreement.