### PR TITLE
Minor typos

### DIFF
--- a/1-source-code/README.md
+++ b/1-source-code/README.md
@@ -4,7 +4,7 @@ In this section we will cover all the different tools that gophers use to manage
 code bases. This includes:
 
 - [1: Worskpace management](1-workspace/1-intro.md) - how to organize a workspace according to Go best practices.
-- [2: Edition tools](2-writing/1-editors-and-plugins.md) - tools to help writing code, such as editors, plugins, and pretty printers.
+- [2: Editor tools](2-writing/1-editors-and-plugins.md) - tools to help writing code, such as editors, plugins, and pretty printers.
 - [3: Navigation tools](3-reading/1-godoc.md) - tools to understand and navigate existing code bases.
 
 Everything here is related to source code, in the next section we cover how from that code


### PR DESCRIPTION
Note `Worskpace` is also spelt incorrectly, but that's resolved in #12.