### PR TITLE
rm localhost to make running examples in Docker accessible

### DIFF
--- a/3-dynamic-analysis/3-profiling/webserver/main.go
+++ b/3-dynamic-analysis/3-profiling/webserver/main.go
@@ -24,7 +24,7 @@ import (
 func main() {
 	http.HandleFunc("/", handler)
 	log.Printf("listening on localhost:8080")
-	log.Fatal(http.ListenAndServe("localhost:8080", nil))
+	log.Fatal(http.ListenAndServe(":8080", nil))
 }
 
 func handler(w http.ResponseWriter, r *http.Request) {

--- a/3-dynamic-analysis/webserver/main.go
+++ b/3-dynamic-analysis/webserver/main.go
@@ -23,7 +23,7 @@ import (
 
 func main() {
 	http.HandleFunc("/", handler)
-	log.Fatal(http.ListenAndServe("localhost:8080", nil))
+	log.Fatal(http.ListenAndServe(":8080", nil))
 }
 
 func handler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Thanks for the awesome workshop today : ) -- not sure if there's a compelling reason to have `localhost:8080` over `:8080` but at least running those examples will make the ports accessible from outside Docker. 